### PR TITLE
Encode publicId in links and wire adminKey input

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 
 function AdminPage() {
   const { publicId } = useParams()
+  const [adminKey, setAdminKey] = useState('')
+  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
 
   return (
     <main>
@@ -9,17 +12,23 @@ function AdminPage() {
       <p>イベントID: {publicId}</p>
       <p>主催者向けの管理画面の雛形です。</p>
       <label htmlFor="adminKey">管理キー</label>
-      <input id="adminKey" name="adminKey" placeholder="admin-key" />
+      <input
+        id="adminKey"
+        name="adminKey"
+        value={adminKey}
+        onChange={(event) => setAdminKey(event.target.value)}
+        placeholder="admin-key"
+      />
       <nav>
         <ul>
           <li>
-            <Link to={`/e/${publicId}`}>回答</Link>
+            <Link to={`/e/${encodedPublicId}`}>回答</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/results`}>結果</Link>
+            <Link to={`/e/${encodedPublicId}/results`}>結果</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/admin`}>主催者</Link>
+            <Link to={`/e/${encodedPublicId}/admin`}>主催者</Link>
           </li>
         </ul>
       </nav>

--- a/src/pages/EditPage.tsx
+++ b/src/pages/EditPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router-dom'
 
 function EditPage() {
   const { publicId, editKey } = useParams()
+  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
 
   return (
     <main>
@@ -12,13 +13,13 @@ function EditPage() {
       <nav>
         <ul>
           <li>
-            <Link to={`/e/${publicId}`}>回答</Link>
+            <Link to={`/e/${encodedPublicId}`}>回答</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/results`}>結果</Link>
+            <Link to={`/e/${encodedPublicId}/results`}>結果</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/admin`}>主催者</Link>
+            <Link to={`/e/${encodedPublicId}/admin`}>主催者</Link>
           </li>
         </ul>
       </nav>

--- a/src/pages/RespondPage.tsx
+++ b/src/pages/RespondPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router-dom'
 
 function RespondPage() {
   const { publicId } = useParams()
+  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
 
   return (
     <main>
@@ -11,13 +12,13 @@ function RespondPage() {
       <nav>
         <ul>
           <li>
-            <Link to={`/e/${publicId}`}>回答</Link>
+            <Link to={`/e/${encodedPublicId}`}>回答</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/results`}>結果</Link>
+            <Link to={`/e/${encodedPublicId}/results`}>結果</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/admin`}>主催者</Link>
+            <Link to={`/e/${encodedPublicId}/admin`}>主催者</Link>
           </li>
         </ul>
       </nav>

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router-dom'
 
 function ResultsPage() {
   const { publicId } = useParams()
+  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
 
   return (
     <main>
@@ -11,13 +12,13 @@ function ResultsPage() {
       <nav>
         <ul>
           <li>
-            <Link to={`/e/${publicId}`}>回答</Link>
+            <Link to={`/e/${encodedPublicId}`}>回答</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/results`}>結果</Link>
+            <Link to={`/e/${encodedPublicId}/results`}>結果</Link>
           </li>
           <li>
-            <Link to={`/e/${publicId}/admin`}>主催者</Link>
+            <Link to={`/e/${encodedPublicId}/admin`}>主催者</Link>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
### Motivation
- Prevent navigation breakage when `publicId` contains characters like `/`, `?`, or `#` by encoding it in URLs.  
- Make the admin key input functional so it can be used for future auth/management flows.  

### Description
- Use `encodeURIComponent(publicId)` (guarded with a ternary) and store it as `encodedPublicId` in `RespondPage`, `ResultsPage`, `EditPage`, and `AdminPage`.  
- Replace uses of raw `publicId` in `Link` `to` paths with the encoded `encodedPublicId`.  
- Add local state for the admin key in `AdminPage` using `useState`, wire `value` and `onChange` on the `adminKey` input.  
- Keep behavior safe when `publicId` is undefined by falling back to an empty string for `encodedPublicId`.

### Testing
- No automated tests were executed for this change.  
- A commit was created including the four modified files: `src/pages/AdminPage.tsx`, `src/pages/RespondPage.tsx`, `src/pages/ResultsPage.tsx`, and `src/pages/EditPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957480c06c88328a949401f24792250)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 複数のページでURLパラメータの適切なエンコーディングを実装しました。特殊文字を含むIDが正しく処理されるようになり、ナビゲーションの安定性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->