### PR TITLE
Handle missing publicId in event pages

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -4,7 +4,17 @@ import { Link, useParams } from 'react-router-dom'
 function AdminPage() {
   const { publicId } = useParams()
   const [adminKey, setAdminKey] = useState('')
-  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
+
+  if (!publicId) {
+    return (
+      <main>
+        <h1>エラー</h1>
+        <p>イベントIDが指定されていません。</p>
+      </main>
+    )
+  }
+
+  const encodedPublicId = encodeURIComponent(publicId)
 
   return (
     <main>

--- a/src/pages/EditPage.tsx
+++ b/src/pages/EditPage.tsx
@@ -2,7 +2,17 @@ import { Link, useParams } from 'react-router-dom'
 
 function EditPage() {
   const { publicId, editKey } = useParams()
-  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
+
+  if (!publicId) {
+    return (
+      <main>
+        <h1>エラー</h1>
+        <p>イベントIDが指定されていません。</p>
+      </main>
+    )
+  }
+
+  const encodedPublicId = encodeURIComponent(publicId)
 
   return (
     <main>

--- a/src/pages/RespondPage.tsx
+++ b/src/pages/RespondPage.tsx
@@ -2,7 +2,17 @@ import { Link, useParams } from 'react-router-dom'
 
 function RespondPage() {
   const { publicId } = useParams()
-  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
+
+  if (!publicId) {
+    return (
+      <main>
+        <h1>エラー</h1>
+        <p>イベントIDが指定されていません。</p>
+      </main>
+    )
+  }
+
+  const encodedPublicId = encodeURIComponent(publicId)
 
   return (
     <main>

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -2,7 +2,17 @@ import { Link, useParams } from 'react-router-dom'
 
 function ResultsPage() {
   const { publicId } = useParams()
-  const encodedPublicId = publicId ? encodeURIComponent(publicId) : ''
+
+  if (!publicId) {
+    return (
+      <main>
+        <h1>エラー</h1>
+        <p>イベントIDが指定されていません。</p>
+      </main>
+    )
+  }
+
+  const encodedPublicId = encodeURIComponent(publicId)
 
   return (
     <main>


### PR DESCRIPTION
### Motivation
- Previously `encodedPublicId` defaulted to an empty string when `publicId` was missing, producing invalid URLs like `/e/` and `/e//results` and causing navigation failures.
- `publicId` is a required route parameter for event pages, so missing cases need explicit handling.
- Show a clear error UI when `publicId` is not present to avoid rendering pages with broken links.

### Description
- Add an early-return guard to `RespondPage`, `ResultsPage`, `AdminPage`, and `EditPage` that renders an error message when `publicId` is missing.
- Compute `encodedPublicId` only after verifying `publicId` exists by calling `encodeURIComponent(publicId)`.
- Avoid building navigation `Link` targets with an empty `publicId` to prevent invalid routes.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the app served successfully.
- Ran a Playwright script that opened `http://localhost:4173/e//results` and captured a screenshot artifact showing the missing-`publicId` error page (succeeded).
- No automated unit or integration test suite was executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69574cf7a9f083288285221d9640f7e9)