### PR TITLE
Brighten scheduler layout with playful kid-friendly theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,173 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  min-height: 100vh;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app-shell {
+  min-height: 100vh;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  color: #1f2937;
+}
+
+.app-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #f97316;
+}
+
+.app-title {
+  margin: 0.35rem 0 0;
+  font-size: clamp(2rem, 3.4vw, 3rem);
+  font-weight: 800;
+}
+
+.app-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 2px solid #fde68a;
+  color: #92400e;
+  font-size: 0.85rem;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.2);
+}
+
+.status-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f97316, #ec4899);
+  box-shadow: 0 0 10px rgba(249, 115, 22, 0.7);
+}
+
+.app-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+main {
+  background: rgba(255, 255, 255, 0.85);
+  border: 2px solid #fde68a;
+  border-radius: 28px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 24px 40px rgba(59, 130, 246, 0.15);
+  backdrop-filter: blur(12px);
+  color: #1f2937;
+}
+
+main h1 {
+  margin-top: 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.5rem);
+}
+
+main p {
+  color: #4b5563;
+  margin: 0.5rem 0;
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+form > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 700;
+  color: #111827;
+}
+
+input {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.8rem 1rem;
+  border-radius: 16px;
+  border: 2px solid #bfdbfe;
+  background: #ffffff;
+  color: #1f2937;
+  font-size: 1rem;
+  box-shadow: inset 0 2px 6px rgba(59, 130, 246, 0.08);
+}
+
+input::placeholder {
+  color: #9ca3af;
+}
+
+button {
+  border: none;
+  border-radius: 16px;
+  padding: 0.8rem 1.6rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #f97316, #ec4899);
+  box-shadow: 0 16px 28px rgba(236, 72, 153, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 18px 32px rgba(236, 72, 153, 0.35);
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+nav a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 2px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+nav a:hover {
+  transform: translateY(-1px);
+  border-color: #f97316;
+  background: #ffedd5;
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
-  to {
-    transform: rotate(360deg);
+
+  .app-status {
+    align-self: flex-start;
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,14 +8,28 @@ import ResultsPage from './pages/ResultsPage'
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/e/:publicId" element={<RespondPage />} />
-      <Route path="/e/:publicId/results" element={<ResultsPage />} />
-      <Route path="/e/:publicId/admin" element={<AdminPage />} />
-      <Route path="/e/:publicId/edit/:editKey" element={<EditPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <p className="app-eyebrow">Schedule Sync</p>
+          <p className="app-title">スマートなスケジュール調整</p>
+        </div>
+        <div className="app-status">
+          <span className="status-dot" aria-hidden="true" />
+          <span>Planning in motion</span>
+        </div>
+      </header>
+      <div className="app-content">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/e/:publicId" element={<RespondPage />} />
+          <Route path="/e/:publicId/results" element={<ResultsPage />} />
+          <Route path="/e/:publicId/admin" element={<AdminPage />} />
+          <Route path="/e/:publicId/edit/:editKey" element={<EditPage />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </div>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'M PLUS Rounded 1c', 'Nunito', 'Segoe UI', system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #1f2937;
+  background-color: #fff7ed;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -14,55 +11,28 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #f97316;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(251, 191, 36, 0.25), transparent 50%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.2), transparent 45%),
+    radial-gradient(circle at 40% 60%, rgba(244, 114, 182, 0.22), transparent 55%),
+    #fff7ed;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+* {
+  box-sizing: border-box;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+img {
+  max-width: 100%;
+  display: block;
 }


### PR DESCRIPTION
### Motivation
- The previous dark/glassmorphism styling was hard to read and not suitable for a kid-friendly, pop aesthetic. 
- Update the visual system to a brighter, more playful palette and rounded, approachable typography. 
- Provide a clearer top-level shell and status area to improve hierarchy and context on every page. 
- Improve visibility of form controls, buttons, and navigation for easier interaction. 

### Description
- Replaced the root app layout by wrapping routes in a new `.app-shell` with a header and status strip in `src/App.tsx`. 
- Rewrote `src/App.css` to introduce bright surfaces, warm borders, playful gradients, rounded controls, and updated styles for buttons, inputs, and nav pills. 
- Updated `src/index.css` to switch the font stack to rounded/child-friendly fonts, set a warm gradient background, and simplify base rules like `box-sizing` and image handling. 
- Removed darker glassmorphism surfaces in favor of lighter cards and added responsive layout tweaks for small screens. 

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the Vite server reported ready (succeeded). 
- Ran an automated Playwright screenshot script which produced `artifacts/schedule-layout-home-pop.png` to verify the visual changes (succeeded). 
- No unit or integration tests were added for these visual-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575096bdb08328a0287d4027bd5997)